### PR TITLE
Generate META.coq-rewriter from a template for Rocq >= 9.3 compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ src/Rewriter/Util/plugins/ltac2_extra.ml
 src/Rewriter/Util/plugins/ltac2_extra.mli
 src/Rewriter/Util/plugins/ltac2_extra_plugin.mlg
 src/Rewriter/Util/plugins/ltac2_extra_plugin.mllib
+src/Rewriter/Util/plugins/META.coq-rewriter
 
 src/Rewriter/Util/Tactics2/Constr.v
 src/Rewriter/Util/Tactics2/DestCase.v

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,14 @@ endif
 _CoqProject: _CoqProject.in
 	sed 's?@META@?$(META_FILE_FRAGMENT)?g' $< > $@
 
+# The META file must exist before we run coq_makefile (it is referenced
+# in _CoqProject), so the rule to make it from its template lives here
+# rather than in Makefile.local-late
+ifneq (,$(META_FILE_FRAGMENT))
+$(META_FILE_FRAGMENT) : % : %.in $(COQ_VERSION_FILE)
+	sed 's?@ROCQ_RUNTIME_PACKAGE@?$(ROCQ_RUNTIME_PACKAGE)?g' $< > $@
+endif
+
 # This target is used to update the _CoqProject file.
 # But it only works if we have git
 ifneq (,$(wildcard .git/))
@@ -79,7 +87,7 @@ EXTRA_SED_FOR_DEPS:=| sed s'/-include $$(ALLDFILES)/include $$(ALLDFILES)/g'
 endif
 
 # We must work around COQBUG(https://github.com/coq/coq/issues/10907) and fix the conf target
-Makefile.coq Makefile-old.conf: Makefile _CoqProject $(COQ_VERSION_FILE)
+Makefile.coq Makefile-old.conf: Makefile _CoqProject $(COQ_VERSION_FILE) $(META_FILE_FRAGMENT)
 	$(SHOW)'COQ_MAKEFILE -f _CoqProject > Makefile.coq'
 	$(HIDE)(($(COQBIN)coq_makefile -f _CoqProject -o Makefile-old && cat Makefile-old | sed s'/Makefile-old.conf:/Makefile-old-old.conf:/g' | sed 's/Makefile-old.local/Makefile.local/g; s/^-\?include Makefile.local-late$$//g' $(EXTRA_SED_FOR_DEPS)); echo; echo 'include Makefile.local-late') > Makefile.coq && rm Makefile-old
 

--- a/Makefile.local-late
+++ b/Makefile.local-late
@@ -9,7 +9,7 @@ $(COMPATIBILITY_FILES) : % : %$(EXPECTED_EXT) $(COQ_VERSION_FILE)
 	$(HIDE)cp $< $@
 
 # ensure that the ml compat files exist before we call coqdep on the corresponding .v files
-$(ALLDFILES): $(COMPATIBILITY_FILES) $(COQ_VERSION_FILE) _CoqProject
+$(ALLDFILES): $(COMPATIBILITY_FILES) $(META_FILE_FRAGMENT) $(COQ_VERSION_FILE) _CoqProject
 
 OTHERFLAGS += -w -notation-overridden
 ifneq ($(PROFILE),)
@@ -17,4 +17,4 @@ OTHERFLAGS += -profile-ltac
 endif
 
 # Kludge around COQBUG(https://github.com/coq/coq/issues/16591)
-FINDLIBPKGS += -package coq-core.plugins.ltac2
+FINDLIBPKGS += -package $(ROCQ_RUNTIME_PACKAGE).plugins.ltac2

--- a/Makefile.local.common
+++ b/Makefile.local.common
@@ -83,6 +83,16 @@ endif
 endif
 endif
 
+# The findlib package containing the core plugins (ltac, ltac2, etc) is
+# coq-core in Coq 8.x; from Rocq 9.0 on it is rocq-runtime, and the
+# coq-core compatibility aliases were removed in
+# https://github.com/rocq-prover/rocq/pull/21955
+ifneq (,$(filter 8.%,$(COQ_VERSION)))
+ROCQ_RUNTIME_PACKAGE := coq-core
+else
+ROCQ_RUNTIME_PACKAGE := rocq-runtime
+endif
+
 COMPATIBILITY_FILES := \
 	src/Rewriter/Util/plugins/definition_by_tactic.ml \
 	src/Rewriter/Util/plugins/definition_by_tactic.mli \

--- a/etc/ci/describe-system-config.sh
+++ b/etc/ci/describe-system-config.sh
@@ -49,6 +49,9 @@ group ocamlfind query coq
 group ocamlfind query coq-core
 group ocamlfind query coq-core.plugins
 group ocamlfind query coq-core.plugins.ltac
+group ocamlfind query rocq-runtime
+group ocamlfind query rocq-runtime.plugins
+group ocamlfind query rocq-runtime.plugins.ltac
 group "ocamlfind query coq | xargs find"
 group coqc --config
 group coqc --version

--- a/src/Rewriter/Util/plugins/META.coq-rewriter.in
+++ b/src/Rewriter/Util/plugins/META.coq-rewriter.in
@@ -1,7 +1,7 @@
 package "strategy_tactic" (
   directory = "."
   description = "Coq Strategy Tactic"
-  requires = "coq-core.plugins.ltac"
+  requires = "@ROCQ_RUNTIME_PACKAGE@.plugins.ltac"
   archive(byte) = "strategy_tactic_plugin.cma"
   archive(native) = "strategy_tactic_plugin.cmxa"
   plugin(byte) = "strategy_tactic_plugin.cma"
@@ -10,7 +10,7 @@ package "strategy_tactic" (
 package "definition_by_tactic" (
   directory = "."
   description = "Coq Definition By Tactic"
-  requires = "coq-core.plugins.ltac"
+  requires = "@ROCQ_RUNTIME_PACKAGE@.plugins.ltac"
   archive(byte) = "definition_by_tactic_plugin.cma"
   archive(native) = "definition_by_tactic_plugin.cmxa"
   plugin(byte) = "definition_by_tactic_plugin.cma"
@@ -19,7 +19,7 @@ package "definition_by_tactic" (
 package "inductive_from_elim" (
   directory = "."
   description = "Coq Inductive From Elim"
-  requires = "coq-core.plugins.ltac"
+  requires = "@ROCQ_RUNTIME_PACKAGE@.plugins.ltac"
   archive(byte) = "inductive_from_elim_plugin.cma"
   archive(native) = "inductive_from_elim_plugin.cmxa"
   plugin(byte) = "inductive_from_elim_plugin.cma"
@@ -28,7 +28,7 @@ package "inductive_from_elim" (
 package "rewriter_build" (
   directory = "."
   description = "Coq Rewriter Build"
-  requires = "coq-core.plugins.ltac"
+  requires = "@ROCQ_RUNTIME_PACKAGE@.plugins.ltac"
   archive(byte) = "rewriter_build_plugin.cma"
   archive(native) = "rewriter_build_plugin.cmxa"
   plugin(byte) = "rewriter_build_plugin.cma"
@@ -37,7 +37,7 @@ package "rewriter_build" (
 package "ltac2_extra" (
   directory = "."
   description = "Coq Ltac2 Extra Tactics"
-  requires = "coq-core.plugins.ltac2"
+  requires = "@ROCQ_RUNTIME_PACKAGE@.plugins.ltac2"
   archive(byte) = "ltac2_extra_plugin.cma"
   archive(native) = "ltac2_extra_plugin.cmxa"
   plugin(byte) = "ltac2_extra_plugin.cma"


### PR DESCRIPTION
https://github.com/rocq-prover/rocq/pull/21955 (in the dev builds of
Rocq 9.3) removed the coq-core.* findlib compatibility aliases, so the
static `requires = "coq-core.plugins.ltac"` lines in META.coq-rewriter
now fail on rocq dev with:

    findlib error: coq-core.plugins.ltac not found
    ...
    required by `coq-rewriter.rewriter_build'

The real findlib package has been rocq-runtime.plugins.ltac since
Rocq 9.0, but Coq 8.x only has coq-core.plugins.ltac, so the META file
is now generated from META.coq-rewriter.in by substituting
@ROCQ_RUNTIME_PACKAGE@ with coq-core on 8.x and rocq-runtime on 9.x,
following the same sed-template pattern as _CoqProject.in.

The generation rule lives in the top-level Makefile (not
Makefile.local-late) because the META file is referenced from
_CoqProject and hence must exist before coq_makefile runs; Makefile.coq
now depends on it, and the .d files depend on it so it is regenerated
before coqdep needs it (and re-made when the Coq version changes, since
it depends on the .coq-version file).

Also use $(ROCQ_RUNTIME_PACKAGE) for the FINDLIBPKGS ltac2 kludge, and
query the rocq-runtime packages in describe-system-config.sh.

This unbreaks the docker-master / dev CI builds of rewriter and of
fiat-crypto (via its rewriter submodule).

https://claude.ai/code/session_01PjCbMk9zjAZWvZHuznFXqh